### PR TITLE
Replace (Bits f, Fractional f) with PrimeField f

### DIFF
--- a/arithmetic-circuits.cabal
+++ b/arithmetic-circuits.cabal
@@ -56,7 +56,7 @@ library
     , galois-fft      >=0.1.0 && <0.2
     , galois-field    >=1.0.0 && <2.0.0
     , MonadRandom     >=0.5.1 && <0.6
-    , poly            >=0.3.2 && <0.4
+    , poly            >=0.3.2 && <0.5
     , process-extras  >=0.7.4 && <0.8
     , protolude       >=0.2   && <0.3
     , semirings       >=0.5.0 && <0.6
@@ -96,7 +96,7 @@ test-suite circuit-tests
     , galois-field          >=1.0.0 && <2.0.0
     , MonadRandom           >=0.5.1 && <0.6
     , pairing               >=1.0   && <1.1
-    , poly                  >=0.3.2 && <0.4
+    , poly                  >=0.3.2 && <0.5
     , process-extras        >=0.7.4 && <0.8
     , protolude             >=0.2   && <0.3
     , QuickCheck            >=2.12  && <2.14
@@ -136,7 +136,7 @@ test-suite readme-test
     , markdown-unlit       >=0.5   && <0.6
     , MonadRandom          >=0.5.1 && <0.6
     , pairing              >=1.0   && <1.1
-    , poly                 >=0.3.2 && <0.4
+    , poly                 >=0.3.2 && <0.5
     , process-extras       >=0.7.4 && <0.8
     , protolude            >=0.2   && <0.3
     , semirings            >=0.5.0 && <0.6
@@ -174,7 +174,7 @@ benchmark circuit-benchmarks
     , galois-field         >=1.0.0 && <2.0.0
     , MonadRandom          >=0.5.1 && <0.6
     , pairing              >=1.0   && <1.1
-    , poly                 >=0.3.2 && <0.4
+    , poly                 >=0.3.2 && <0.5
     , process-extras       >=0.7.4 && <0.8
     , protolude            >=0.2   && <0.3
     , semirings            >=0.5.0 && <0.6

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,7 @@ dependencies:
   - vector          >= 0.12  && < 0.13
 
   # Algebra
-  - poly            >= 0.3.2 && < 0.4
+  - poly            >= 0.3.2 && < 0.5
   - semirings       >= 0.5.0 && < 0.6
 
   # Cryptography

--- a/src/Circuit/Arithmetic.hs
+++ b/src/Circuit/Arithmetic.hs
@@ -23,6 +23,7 @@ where
 import Circuit.Affine               (AffineCircuit(..), collectInputsAffine,
                                      evalAffineCircuit, mapVarsAffine)
 import Data.Aeson                   (FromJSON, ToJSON)
+import Data.Field.Galois            (PrimeField, fromP)
 import Protolude
 import Text.PrettyPrint.Leijen.Text as PP (Pretty(..), hsep, list, parens, text,
                                            vcat)
@@ -103,7 +104,7 @@ mapVarsGate f = \case
 
 -- | Evaluate a single gate
 evalGate ::
-  (Bits f, Fractional f) =>
+  (PrimeField f) =>
   -- | lookup a value at a wire
   (i -> vars -> Maybe f) ->
   -- | update a value at a wire
@@ -139,7 +140,7 @@ evalGate lookupVar updateVar vars gate =
               bool2val False = 0
               setWire (ix, oldEnv) currentOut =
                 ( ix + 1,
-                  updateVar currentOut (bool2val $ testBit inp ix) oldEnv
+                  updateVar currentOut (bool2val $ testBit (fromP inp) ix) oldEnv
                 )
            in snd . foldl setWire (0, vars) $ os
 
@@ -219,7 +220,7 @@ generateRoots takeRoot (ArithCircuit (gate : gates)) =
 -- values and inputs).
 evalArithCircuit ::
   forall f vars.
-  (Bits f, Fractional f) =>
+  (PrimeField f) =>
   -- | lookup a value at a wire
   (Wire -> vars -> Maybe f) ->
   -- | update a value at a wire

--- a/src/Circuit/Expr.hs
+++ b/src/Circuit/Expr.hs
@@ -24,6 +24,7 @@ where
 
 import Circuit.Affine
 import Circuit.Arithmetic
+import Data.Field.Galois (PrimeField, fromP)
 import Protolude
 import Text.PrettyPrint.Leijen.Text hiding ((<$>))
 
@@ -138,7 +139,7 @@ truncRotate nbits nrots x =
 
 -- | Evaluate arithmetic expressions directly, given an environment
 evalExpr ::
-  (Bits f, Num f) =>
+  (PrimeField f) =>
   -- | variable lookup
   (i -> vars -> Maybe f) ->
   -- | expression to evaluate
@@ -161,7 +162,7 @@ evalExpr lookupVar expr vars = case expr of
   EUnOp UNot e1 ->
     not $ evalExpr lookupVar e1 vars
   EUnOp (URot truncBits rotBits) e1 ->
-    truncRotate truncBits rotBits $ evalExpr lookupVar e1 vars
+    fromInteger $ truncRotate truncBits rotBits $ fromP $ evalExpr lookupVar e1 vars
   EBinOp op e1 e2 ->
     (evalExpr lookupVar e1 vars) `apply` (evalExpr lookupVar e2 vars)
     where

--- a/src/QAP.hs
+++ b/src/QAP.hs
@@ -49,7 +49,7 @@ import qualified Data.Map.Merge.Lazy as Merge
 
 import           Data.Euclidean               (Euclidean(..))
 import           Data.Field                   (Field)
-import           Data.Field.Galois            (GaloisField, Prime, pow)
+import           Data.Field.Galois            (GaloisField, PrimeField, Prime, fromP, pow)
 import           Data.Poly
 import qualified Data.Vector                  as V
 import           Text.PrettyPrint.Leijen.Text (Pretty(..), enclose, indent,
@@ -84,8 +84,10 @@ instance (ToJSON f, Generic f) => ToJSON (VPoly f) where
 instance (FromJSON f, Generic f, Eq f, Num f) => FromJSON (VPoly f) where
   parseJSON v = toPoly <$> parseJSON v
 
-instance ToJSON (Prime n)
-instance FromJSON (Prime n)
+instance KnownNat n => ToJSON (Prime n) where
+  toJSON = toJSON . fromP
+instance KnownNat n => FromJSON (Prime n) where
+  parseJSON = fmap fromInteger . parseJSON
 
 -- | Generalised quadratic arithmetic program: instead of @Poly@, allow
 -- any functor.
@@ -575,7 +577,7 @@ addMissingZeroes allRoots (GenQAP inpLeft inpRight outp t)
 
 -- | Generate a valid assignment for a single gate.
 generateAssignmentGate
-  :: (Bits f, Fractional f)
+  :: (PrimeField f)
   => Gate Wire f -- ^ program
   -> Map Int f -- ^ inputs
   -> QapSet f
@@ -593,7 +595,7 @@ initialQapSet
 initialQapSet inputs = QapSet 1 inputs Map.empty Map.empty
 
 generateAssignment
-  :: forall f . (Bits f, Fractional f)
+  :: forall f . (PrimeField f)
   => ArithCircuit f -- ^ program
   -> Map Int f -- ^ inputs
   -> QapSet f


### PR DESCRIPTION
This PR reflects changes to `galois-field`, made in https://github.com/adjoint-io/galois-field/pull/29, and replaces `(Bits f, Fractional f)` with `PrimeField f`. Note that prime galois field were the only ones, which defined `Bits` instance prior to https://github.com/adjoint-io/galois-field/pull/29.